### PR TITLE
graph api が使用できる状態にバージョン変更

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -296,9 +296,9 @@ tzdata==2023.3
     # via pandas
 urllib3==2.0.7
     # via requests
-uvicorn[standard]==0.23.2
+uvicorn==0.23.2
     # via -r requirements.in
-uvloop==0.17.0
+# uvloop==0.17.0
     # via uvicorn
 watchfiles==0.20.0
     # via uvicorn
@@ -325,5 +325,5 @@ zipp==3.17.0
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
 
-
-msgraph-sdk==1.0.0a14
+microsoft-kiota-abstractions==0.8.5
+msgraph-sdk==1.0.0a15


### PR DESCRIPTION
# 概要
Graph API を正常に叩けるように調整しました。

# 動作画面
![image](https://github.com/07JP27/azureopenai-internal-microsoft-search/assets/70362624/7449dfb0-9e66-43f5-9e16-8668613ec88c)

result からが graph api を読んだ結果ですが、正常にドライブの中身が取れています。

# 変更点
- microsoft-graph-sdk のバージョンを 1.0.0a14 → 1.0.0a15 に変更
- microsoft-kiota-abstractions を追加

# 注意点
windows 環境での環境構築をする際に以下の調整が必要でした。

- vite.config.ts の proxy を
http://localhost:5000/
→
http://127.0.0.1:5000/
に変更する必要がありました。

- uvloop というライブラリを削除する必要がありました
- msgraph-sdk をインストールする際、以下のエラーが出る可能性あります

```
I
nstalling collected packages: msgraph-sdk ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: 'C:\\Users\\ryuseioya\\Desktop\\business\\tsuchida-san\\clone-branch\\azureopenai-internal-microsoft-search\\myenv\\Lib\\site-packages\\msgraph\\generated\\authentication_methods_policy\\authentication_method_configurations\\authentication_method_configurations_request_builder.py' HINT: This error might have occurred since this system does not have Windows Long Path support enabled. You can find information on how to enable this at
https://pip.pypa.io/warnings/enable-long-paths
```

この場合以下の調整をすることで解決できました。

1. レジストリエディタを開きます
Win + R キーを押して、Run ダイアログボックスを開きます。
regedit と入力し、OK をクリックします。
2. レジストリエディタ内で次のキーに移動します
arduinoCopy codeHKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem
3. 右側のペインで、
LongPathsEnabled
という名前のDWORD値を探します
この値が存在しない場合は、右クリックして新規 > DWORD値 (32 ビット) の作成 を選択し、名前を LongPathsEnabled としてください。
4. レジストリエディタを閉じて、コンピュータを再起動します